### PR TITLE
Linting and formating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,168 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/README.md
+++ b/README.md
@@ -1,20 +1,25 @@
-# python-enigma: Engima Machines, But With Python
-This project introduces a package, python_enigma, with an `enigma` module which can be imported and used to include Enigma-Machine-like encryption to your python project. Also included is a simplistic "Hello World" proof of concept, a basic catalogue of rotors in the jason format expected (`catalogue.json`), and a convenience script for preparing the catalogue from a csv.
+# python-enigma: Enigma Machines, But With Python
+
+This project introduces a package, python_enigma, with an `enigma` module which can be imported and used to include Enigma-Machine-like encryption to your python project. Also included is a simplistic "Hello World" proof of concept, a basic catalogue of rotors in the JSON format expected (`catalogue.json`), and a convenience script for preparing the catalogue from a csv.
 
 ## Security Notice
+
 In the age of gigahertz pocket computing, the Enigma cipher is useful as a point of curiosity only. None of the original security flaws with the Enigma machine as patented have been corrected.
 
 ## Historical Accuracy Notice
+
 While pains were taken to ensure the interoperability of this emulator and the actual enigma machine, nothing about the module enforces historical accuracy in terms of the use of particular parts or settings, or the "tidying" features of the operator.
 
-In particular, this model allows for an aribtrary number of wheels to be used, some of which were not historically used together. All wheels obey an M3/M4-style "double stepping" movement pattern. The smoother gearbox stepping patterns of some later models are not emulated.
+In particular, this model allows for an arbitrary number of wheels to be used, some of which were not historically used together. All wheels obey an M3/M4-style "double stepping" movement pattern. The smoother gearbox stepping patterns of some later models are not emulated.
 
 ## Making use
+
 The principle way to use the Enigma module in your scripts is to import and invoke the Enigma class. For convenience, you can read in the string "default" as the catalog list to use the stock catalog included in the module.
 
 The Enigma class accepts the following arguments on initialization:
+
 - catalog: a dictionary of rotor bindings, or the string "default" to use the stock bindings included in the module.
-- stecker: A space-seperated string of bindings to use for the steckerboard settings. Ex, "AB CD" means that stecker cables are set between A and B, and C and D.
+- stecker: A space-separated string of bindings to use for the steckerboard settings. Ex, "AB CD" means that stecker cables are set between A and B, and C and D.
 - rotors: a list of tuples showing the rotor name from the catalog and the desired ringstellung letter setting, ex `[("III", "D"),]`. Any number of rotors may be used, including duplicates.
 - reflector: a string indicating the name of the rotor from the rotor catalogue which you would like to use for the reflector, ex 'Reflector B'.
 - operator: if True, the operator class will be used. This strips unprintable characters from the message and cuts the message into 5-character chunks.
@@ -22,6 +27,7 @@ The Enigma class accepts the following arguments on initialization:
 - stator: accepts "military" or "civilian", to imitate either the direct encoding of the military version of the device or the QWERTZ encoding used in the civilian model.
 
 Use of the Enigma class provides a variety of convenience methods:
+
 - set_wheels: accepts a string of wheel positions (as read left to right) and applies them to be the message setting. Should be called before every parse call.
 - set_stecker: if desirable, one could override the steckerboard settings after instantiating the entire machine.
 - parse: parses the string provided and returns that message as though it were processed through an actual Enigma Machine.

--- a/python_enigma/__init__.py
+++ b/python_enigma/__init__.py
@@ -1,3 +1,3 @@
 __version__ = "1.2devSomething"
 
-from .enigma import *
+from .enigma import *  # noqa: F403

--- a/python_enigma/__main__.py
+++ b/python_enigma/__main__.py
@@ -19,7 +19,20 @@ Development was by Zac Adam-MacEwen. See the README.md for details.
 __version__ = "1.2.0Dev"
 
 from . import enigma
-from tkinter import *
+from tkinter import (
+    Button,
+    CENTER,
+    Entry,
+    Frame,
+    Label,
+    LabelFrame,
+    LEFT,
+    Message,
+    StringVar,
+    Text,
+    Tk,
+    Toplevel,
+)
 import webbrowser
 
 # We really only need things to execute here if being called as main, such as `python -m python_enigma`

--- a/python_enigma/__main__.py
+++ b/python_enigma/__main__.py
@@ -143,7 +143,7 @@ if __name__ == "__main__":
     settings_pane = LabelFrame(
         window, text="Machine State", height=input_pane.winfo_height(), width=537
     )
-    settings_pane.grid_propagate(0)
+    settings_pane.grid_propagate(False)
     settings_pane.grid(column=1, row=0)
     controls_pane = Frame(window)
     controls_pane.grid(column=1, row=1)

--- a/python_enigma/__main__.py
+++ b/python_enigma/__main__.py
@@ -46,20 +46,24 @@ def test_button():  # TODO Remove when no longer relied upon
 def display_about_window():
     about_window = Toplevel(window)
     box = LabelFrame(about_window, text="About Python Enigma")
-    about_blurb = "This is a toy project intending to implement the Enigma Machine as originally " \
-                  "designed by Arthur Scherbius. Enigma was an electromechanical implementation of " \
-                  "a polyalphabetic substitution cypher. It's no longer considered " \
-                  "cryptographically secure, but the device itself was fairly interesting.\n\n" \
-                  "No effort has been made to correct any of the cryptographic flaws in enigma; " \
-                  "this implementation is meant to be as faithful as possible. Additionally, " \
-                  "steps have been taken to attempt to emulate not just the Wehrmacht enigma, but " \
-                  "the commercial models as well.\n\nFurther information is available using the links below." \
-                  "\n\nThis is a work product of Kensho Security Labs," \
-                  " provided under the Apache 2.0 License."
+    about_blurb = (
+        "This is a toy project intending to implement the Enigma Machine as originally "
+        "designed by Arthur Scherbius. Enigma was an electromechanical implementation of "
+        "a polyalphabetic substitution cypher. It's no longer considered "
+        "cryptographically secure, but the device itself was fairly interesting.\n\n"
+        "No effort has been made to correct any of the cryptographic flaws in enigma; "
+        "this implementation is meant to be as faithful as possible. Additionally, "
+        "steps have been taken to attempt to emulate not just the Wehrmacht enigma, but "
+        "the commercial models as well.\n\nFurther information is available using the links below."
+        "\n\nThis is a work product of Kensho Security Labs,"
+        " provided under the Apache 2.0 License."
+    )
     box.grid(row=0, column=0)
     text = Message(box, text=about_blurb, width=500)
     text.pack()
-    ks_button = Button(box, text="Kensho Security Labs", command=launch_kenshosec, width=15)
+    ks_button = Button(
+        box, text="Kensho Security Labs", command=launch_kenshosec, width=15
+    )
     gh_button = Button(box, text="Github Project Page", command=launch_github, width=15)
     gh_button.pack()
     ks_button.pack()
@@ -69,11 +73,15 @@ def fill_wheel_states():
     wheel_state_raw = machine_used.wheel_pack.rotors.copy()
     wheel_state_raw.reverse()  # wheels will now appear in visible order, as indexed.
     counter = 1
-    for rotor in wheel_state_raw:  # we can iterate over these to start filling the parent.
+    for (
+        rotor
+    ) in wheel_state_raw:  # we can iterate over these to start filling the parent.
         readable_pos = enigma.num_to_alpha(rotor.position)
         wheel_id = rotor.name
         ringstellung = rotor.ringstellung
-        new_wheel = LabelFrame(wheel_states, width=25, height=25, text=("%s" % str(counter)))
+        new_wheel = LabelFrame(
+            wheel_states, width=25, height=25, text=("%s" % str(counter))
+        )
         new_wheel.pack(side=LEFT)
         pos_var = StringVar()
         pos_var.set(readable_pos)
@@ -92,10 +100,19 @@ def fill_wheel_states():
         rings_setting.grid(row=2, column=1)
         counter += 1
 
+
 def initialize_stock_enigma():
     use_these = [("Beta", "A"), ("I", "A"), ("II", "A"), ("III", "A")]
-    machine = enigma.Enigma(catalog="default", stecker=None, stator="military", rotors=use_these, reflector="UKW",
-                            operator=True, word_length=5, ignore_static_wheels=False)
+    machine = enigma.Enigma(
+        catalog="default",
+        stecker=None,
+        stator="military",
+        rotors=use_these,
+        reflector="UKW",
+        operator=True,
+        word_length=5,
+        ignore_static_wheels=False,
+    )
     return machine
 
 
@@ -123,7 +140,9 @@ if __name__ == "__main__":
     output_field = Text(output_pane, width=80, height=24)
     output_field.pack()
     window.update()  # Needed because we're taking some dynamic sizes!
-    settings_pane = LabelFrame(window, text="Machine State", height=input_pane.winfo_height(), width=537)
+    settings_pane = LabelFrame(
+        window, text="Machine State", height=input_pane.winfo_height(), width=537
+    )
     settings_pane.grid_propagate(0)
     settings_pane.grid(column=1, row=0)
     controls_pane = Frame(window)
@@ -131,24 +150,37 @@ if __name__ == "__main__":
 
     # This code populates the various items that need to go in the settings pane
     # This pane uses grid geometry.
-    wheel_selections = Button(settings_pane, command=test_button, text="Select Wheels")  # TODO Define Correct Command
+    wheel_selections = Button(
+        settings_pane, command=test_button, text="Select Wheels"
+    )  # TODO Define Correct Command
     wheel_selections.grid_anchor(CENTER)
     wheel_selections.grid(column=0, row=0)
-    stecker_config = Button(settings_pane, command=test_button, text="Steckerboard Config")
+    stecker_config = Button(
+        settings_pane, command=test_button, text="Steckerboard Config"
+    )
     stecker_config.grid_anchor(CENTER)
     stecker_config.grid(column=1, row=0)
     wheel_states = LabelFrame(settings_pane, text="Wheel States")
     wheel_states.grid_anchor(CENTER)
-    #filler = Label(wheel_states, text="We don't fill this frame because that requires a function not yet defined!")
+    # filler = Label(wheel_states, text="We don't fill this frame because that requires a function not yet defined!")
     wheel_states.grid(row=1, columnspan=2)
     wheel_states.grid_anchor(CENTER)
     fill_wheel_states()
-    #filler.pack()
+    # filler.pack()
 
     # This code populates the various items that need to go in the controls pane!
-    go_button = Button(controls_pane, text="Process Message", command=test_button, width=25)  # TODO The Do!
-    reset_button = Button(controls_pane, text="Reset State", command=test_button, width=25)  # TODO def
-    credits_button = Button(controls_pane, text="About python_enigma", command=display_about_window, width=25)
+    go_button = Button(
+        controls_pane, text="Process Message", command=test_button, width=25
+    )  # TODO The Do!
+    reset_button = Button(
+        controls_pane, text="Reset State", command=test_button, width=25
+    )  # TODO def
+    credits_button = Button(
+        controls_pane,
+        text="About python_enigma",
+        command=display_about_window,
+        width=25,
+    )
     go_button.grid(row=0)
     reset_button.grid(row=1)
     credits_button.grid(row=2)

--- a/python_enigma/csvtojson.py
+++ b/python_enigma/csvtojson.py
@@ -14,7 +14,7 @@ with open("table_rotors.csv", "r") as file:
             binding = enigma.alpha_to_num(character.upper())
             new_entry = {counter: binding}
             bindings_dict.update(new_entry)
-            counter+=1
+            counter += 1
         notch = line[2]
 
         catalogue.update({rotor_label: {"wiring": bindings_dict, "notch": notch}})

--- a/python_enigma/csvtojson.py
+++ b/python_enigma/csvtojson.py
@@ -1,6 +1,5 @@
 import csv
 import json
-import os
 from python_enigma import enigma
 
 catalogue = {}

--- a/python_enigma/enigma.py
+++ b/python_enigma/enigma.py
@@ -31,18 +31,15 @@ class SteckerSettingsInvalid(Exception):
 
 
 class UndefinedStatorError(Exception):
-    """Raised if the stator mode string is not a defined stator type
-    """
+    """Raised if the stator mode string is not a defined stator type"""
 
 
 class RotorNotFound(Exception):
-    """Raised if the rotor requested is not found in the catalogue
-    """
+    """Raised if the rotor requested is not found in the catalogue"""
 
 
 class ReflectorNotFound(Exception):
-    """Raised if the refelctor requested is not found in the catalogue
-    """
+    """Raised if the refelctor requested is not found in the catalogue"""
 
 
 class Stecker(object):
@@ -56,7 +53,7 @@ class Stecker(object):
 
     def __init__(self, setting):
         """Accepts a string of space-seperated letter pairs denoting stecker
-         settings, deduplicates them and grants the object its properties.
+        settings, deduplicates them and grants the object its properties.
         """
         if setting is not None:
             stecker_pairs = setting.upper().split(" ")
@@ -73,8 +70,7 @@ class Stecker(object):
                     self.stecker_setting[pair[1]] = pair[0]
 
     def steck(self, char):
-        """Accepts a character and parses it through the stecker board.
-        """
+        """Accepts a character and parses it through the stecker board."""
         if char.upper() in self.stecker_setting:
             return self.stecker_setting[char]
         else:
@@ -105,17 +101,61 @@ class Stator(object):
         self.mode = mode
         if mode == "civilian":
             self.stator_settings = {
-                "Q": 1, "W": 2, "E": 3, "R": 4, "T": 5, "Z": 6, "U": 7, "I": 8,
-                "O": 9, "P": 10, "A": 11, "S": 12, "D": 13, "F": 14, "G": 15,
-                "H": 16, "J": 17, "K": 18, "L": 19, "Y": 20, "X": 21, "C": 22,
-                "V": 23, "B": 24, "N": 25, "M": 26,
+                "Q": 1,
+                "W": 2,
+                "E": 3,
+                "R": 4,
+                "T": 5,
+                "Z": 6,
+                "U": 7,
+                "I": 8,
+                "O": 9,
+                "P": 10,
+                "A": 11,
+                "S": 12,
+                "D": 13,
+                "F": 14,
+                "G": 15,
+                "H": 16,
+                "J": 17,
+                "K": 18,
+                "L": 19,
+                "Y": 20,
+                "X": 21,
+                "C": 22,
+                "V": 23,
+                "B": 24,
+                "N": 25,
+                "M": 26,
             }
         elif mode == "military":
             self.stator_settings = {
-                "A": 1, "B": 2, "C": 3, "D": 4, "E": 5, "F": 6, "G": 7, "H": 8,
-                "I": 9, "J": 10, "K": 11, "L": 12, "M": 13, "N": 14, "O": 15,
-                "P": 16, "Q": 17, "R": 18, "S": 19, "T": 20, "U": 21, "V": 22,
-                "W": 23, "X": 24, "Y": 25, "Z": 26,
+                "A": 1,
+                "B": 2,
+                "C": 3,
+                "D": 4,
+                "E": 5,
+                "F": 6,
+                "G": 7,
+                "H": 8,
+                "I": 9,
+                "J": 10,
+                "K": 11,
+                "L": 12,
+                "M": 13,
+                "N": 14,
+                "O": 15,
+                "P": 16,
+                "Q": 17,
+                "R": 18,
+                "S": 19,
+                "T": 20,
+                "U": 21,
+                "V": 22,
+                "W": 23,
+                "X": 24,
+                "Y": 25,
+                "Z": 26,
             }
         else:
             raise UndefinedStatorError
@@ -131,7 +171,7 @@ class Stator(object):
 
     def destat(self, signal):
         return self.destator[signal]
-    
+
     def __repr__(self):
         return f"Stator({self.mode!r})"
 
@@ -143,6 +183,7 @@ class Rotor(object):
 
     It's worth noting the reflector is also treated as a rotor.
     """
+
     def __init__(self, catalog, rotor_number, ringstellung, ignore_static):
         """Initialize the parameters of this individual rotor.
 
@@ -192,12 +233,14 @@ class Rotor(object):
             self.wiring_back[out_pin] = shifted_input
 
         if not ignore_static:
-            if "static" in description.keys():  # Issue 4: Bravo and Gamma rotor need to be static for m4
+            if (
+                "static" in description.keys()
+            ):  # Issue 4: Bravo and Gamma rotor need to be static for m4
                 if description["static"]:
                     self.static = True
                 else:
                     self.static = False
-    
+
     def __repr__(self):
         return f'Rotor("{self.catalog!r}", {self.name!r}", {self.ringstellung!r}, {self.ignore_static!r})'
 
@@ -208,6 +251,7 @@ class RotorMechanism(object):
     positions. You can process characters one at a time through this object's
     "process" method. Initial settings are passed with the "set" method.
     """
+
     def __init__(self, list_rotors, reflector):
         """Expects a list of rotors and a rotor object representing reflector"""
         self.rotors = list_rotors
@@ -230,10 +274,12 @@ class RotorMechanism(object):
         indexer = -1
         for rotor in self.rotors:
             indexer += 1
-            if rotor.position in rotor.notch:  # If a rotor is at its notch, the one on the left steps.
+            if (
+                rotor.position in rotor.notch
+            ):  # If a rotor is at its notch, the one on the left steps.
                 if rotor.step_me:
                     try:
-                        self.rotors[indexer+1].step_me = True
+                        self.rotors[indexer + 1].step_me = True
                     except IndexError:
                         pass
 
@@ -260,9 +306,10 @@ class RotorMechanism(object):
         output = next_bit
 
         return output
-    
+
     def __repr__(self):
         return f"RotorMechanism({self.rotors!r}, {self.reflector!r})"
+
 
 class Operator(object):
     """A special preparser that does some preformatting to the feed. This
@@ -279,10 +326,19 @@ class Operator(object):
         """Accepts a string as input and does some parsing to it."""
         cased_message = message.upper()
         message_characters = cased_message.replace(" ", "")
-        dict_replacement_characters = {".": "X", ":": "XX", ",": "ZZ", "?": "FRAQ",
-                                       "(": "KLAM", ")": "KLAM", """'""": "X"}
+        dict_replacement_characters = {
+            ".": "X",
+            ":": "XX",
+            ",": "ZZ",
+            "?": "FRAQ",
+            "(": "KLAM",
+            ")": "KLAM",
+            """'""": "X",
+        }
         for punct in dict_replacement_characters:
-            message_characters = message_characters.replace(punct, dict_replacement_characters[punct])
+            message_characters = message_characters.replace(
+                punct, dict_replacement_characters[punct]
+            )
 
         for character in message_characters:
             if character not in "ABCDEFGHIJKLMNOPQRSTUVWXYZ":
@@ -290,11 +346,17 @@ class Operator(object):
 
         m = message_characters
         # This next step adds the spaces which cut the words up.
-        message_spaced = ' '.join([m[i:i+self.word_length] for i in range(0, len(message_characters), self.word_length)])
+        message_spaced = " ".join(
+            [
+                m[i : i + self.word_length]
+                for i in range(0, len(message_characters), self.word_length)
+            ]
+        )
         return message_spaced
 
     def __repr__(self) -> str:
         return f"Operator({self.word_length!r})"
+
 
 class Enigma(object):
     """A magic package that instantiates everything, allowing you to call your
@@ -306,10 +368,17 @@ class Enigma(object):
     - set: change various settings. See below.
     """
 
-    def __init__(self, catalog={}, stecker="", stator="military",
-                 rotors=[["I",0], ["II",0], ["III",0]],
-                 reflector="UKW", operator=True, word_length=5,
-                 ignore_static_wheels=False):
+    def __init__(
+        self,
+        catalog={},
+        stecker="",
+        stator="military",
+        rotors=[["I", 0], ["II", 0], ["III", 0]],
+        reflector="UKW",
+        operator=True,
+        word_length=5,
+        ignore_static_wheels=False,
+    ):
         self.stecker = Stecker(setting=str(stecker))
         self.stator = Stator(mode=stator)
         self.rotor_names = rotors
@@ -332,10 +401,12 @@ class Enigma(object):
             rotor_object = Rotor(catalog, rotor_req, ringstellung, ignore_static_wheels)
             wheels.append(rotor_object)
         try:
-            reflector = Rotor(catalog,
-                              rotor_number=reflector,
-                              ringstellung="A",
-                              ignore_static=ignore_static_wheels)
+            reflector = Rotor(
+                catalog,
+                rotor_number=reflector,
+                ringstellung="A",
+                ignore_static=ignore_static_wheels,
+            )
         except RotorNotFound:
             raise ReflectorNotFound(reflector) from None
         self.wheel_pack = RotorMechanism(wheels, reflector=reflector)
@@ -360,8 +431,8 @@ class Enigma(object):
         """Accepts a string to be the new stecker board arrangement."""
         self.stecker = Stecker(setting=str(setting))
 
-    #def set_wheelpack(self, list_rotors):
-        #self.wheel_pack = RotorMechanism(list_rotors.reverse())
+    # def set_wheelpack(self, list_rotors):
+    # self.wheel_pack = RotorMechanism(list_rotors.reverse())
 
     def parse(self, message="Hello World"):
         if self.operator:
@@ -374,16 +445,20 @@ class Enigma(object):
             if character in "ABCDEFGHIJKLMNOPQRSTUVWXYZ":
                 stecked = self.stecker.steck(character)  # Keystroke - > Stecker
                 stated = self.stator.stat(stecked)  # Stecker -> Stator Wheel
-                polysubbed = self.wheel_pack.process(stated)  # Both ways through wheelpack, wheelpack steps forward.
-                destated = self.stator.destat(polysubbed)  # Backward through the stator wheel
+                polysubbed = self.wheel_pack.process(
+                    stated
+                )  # Both ways through wheelpack, wheelpack steps forward.
+                destated = self.stator.destat(
+                    polysubbed
+                )  # Backward through the stator wheel
                 lamp = self.stecker.steck(destated)  # Again through stecker
                 next_char = lamp
-            else: # Raised if an unformatted message contains special characters
+            else:  # Raised if an unformatted message contains special characters
                 next_char = character
             str_ciphertext += next_char
 
         return str_ciphertext
-    
+
     def __repr__(self):
         return f"""Enigma(catalog={self.catalog},
 stecker={self.stecker.__repr__()},
@@ -398,33 +473,101 @@ ignore_static_wheels={self.ignore_static_wheels})"""
 def alpha_to_index(char):
     """Takes a single character and converts it to a number where A=0"""
     translator = {
-                "A": 0, "B": 1, "C": 2, "D": 3, "E": 4, "F": 5, "G": 6, "H": 7,
-                "I": 8, "J": 9, "K": 10, "L": 11, "M": 12, "N": 13, "O": 14,
-                "P": 15, "Q": 16, "R": 17, "S": 18, "T": 19, "U": 20, "V": 21,
-                "W": 22, "X": 23, "Y": 24, "Z": 25,
-            }
+        "A": 0,
+        "B": 1,
+        "C": 2,
+        "D": 3,
+        "E": 4,
+        "F": 5,
+        "G": 6,
+        "H": 7,
+        "I": 8,
+        "J": 9,
+        "K": 10,
+        "L": 11,
+        "M": 12,
+        "N": 13,
+        "O": 14,
+        "P": 15,
+        "Q": 16,
+        "R": 17,
+        "S": 18,
+        "T": 19,
+        "U": 20,
+        "V": 21,
+        "W": 22,
+        "X": 23,
+        "Y": 24,
+        "Z": 25,
+    }
     return translator[char.upper()]
 
 
 def alpha_to_num(char):
     """Takes a single character and converts it to a number where A=1"""
     translator = {
-                "A": 1, "B": 2, "C": 3, "D": 4, "E": 5, "F": 6, "G": 7, "H": 8,
-                "I": 9, "J": 10, "K": 11, "L": 12, "M": 13, "N": 14, "O": 15,
-                "P": 16, "Q": 17, "R": 18, "S": 19, "T": 20, "U": 21, "V": 22,
-                "W": 23, "X": 24, "Y": 25, "Z": 26,
-            }
+        "A": 1,
+        "B": 2,
+        "C": 3,
+        "D": 4,
+        "E": 5,
+        "F": 6,
+        "G": 7,
+        "H": 8,
+        "I": 9,
+        "J": 10,
+        "K": 11,
+        "L": 12,
+        "M": 13,
+        "N": 14,
+        "O": 15,
+        "P": 16,
+        "Q": 17,
+        "R": 18,
+        "S": 19,
+        "T": 20,
+        "U": 21,
+        "V": 22,
+        "W": 23,
+        "X": 24,
+        "Y": 25,
+        "Z": 26,
+    }
     return translator[char.upper()]
+
 
 def num_to_alpha(integ):
     """takes a numeral value and spits out the corresponding letter."""
     translator = {
-                1: 'A', 2: 'B', 3: 'C', 4: 'D', 5: 'E', 6: 'F', 7: 'G', 8: 'H',
-                9: 'I', 10: 'J', 11: 'K', 12: 'L', 13: 'M', 14: 'N', 15: 'O',
-                16: 'P', 17: 'Q', 18: 'R', 19: 'S', 20: 'T', 21: 'U', 22: 'V',
-                23: 'W', 24: 'X', 25: 'Y', 26: 'Z'
-                }
+        1: "A",
+        2: "B",
+        3: "C",
+        4: "D",
+        5: "E",
+        6: "F",
+        7: "G",
+        8: "H",
+        9: "I",
+        10: "J",
+        11: "K",
+        12: "L",
+        13: "M",
+        14: "N",
+        15: "O",
+        16: "P",
+        17: "Q",
+        18: "R",
+        19: "S",
+        20: "T",
+        21: "U",
+        22: "V",
+        23: "W",
+        24: "X",
+        25: "Y",
+        26: "Z",
+    }
     return translator[integ]
+
 
 def map_faces(rotor):
     """Are you ready for bad entry pinning mapping?"""
@@ -441,4 +584,3 @@ def map_faces(rotor):
         pos += 1
 
     return neutral_to_pins, pins_to_neutral
-

--- a/python_enigma/helloworld.py
+++ b/python_enigma/helloworld.py
@@ -7,13 +7,22 @@ with open("catalogue.json", "r") as file:
     all_wheels = json.load(file)
 
 use_these = [("I", "A"), ("II", "B"), ("III", "C")]
-machine = enigma.Enigma(catalog="default", stecker="AQ BJ",
-                        rotors=use_these, reflector="Reflector B", operator=True, word_length=5, stator="military")
+machine = enigma.Enigma(
+    catalog="default",
+    stecker="AQ BJ",
+    rotors=use_these,
+    reflector="Reflector B",
+    operator=True,
+    word_length=5,
+    stator="military",
+)
 machine.set_wheels("ABC")
 
-print("I am going to try to print HELLO WORLD using the stecker settings\n"
-      "AQ and BJ and rotors I, II, III from the whermacht set.\n"
-      "The ringstellungs are A, B, and C respectively.")
+print(
+    "I am going to try to print HELLO WORLD using the stecker settings\n"
+    "AQ and BJ and rotors I, II, III from the whermacht set.\n"
+    "The ringstellungs are A, B, and C respectively."
+)
 crypted = machine.parse("hello world")
 print(crypted)
 print("If I feed that back through, it decrypts to:")

--- a/setup.py
+++ b/setup.py
@@ -13,5 +13,5 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     include_package_data=True,
     url="https://github.com/ZAdamMac/python-enigma",
-    packages=setuptools.find_packages()
+    packages=setuptools.find_packages(),
 )


### PR DESCRIPTION
The goal of this PR is just to tidy up the source so that it passes linters (ruff, flake8, mypy) and formatters. This will make linting more useful in the future there will be less noise.

## Linters used

`ruff check`
`ruff format`
`mypy` (not strict)
Whatever Markdown linter I have in VSCode.

## The difficult choice

Linters (correctly) don't like things like

```python
from tkinter import *
```

because it leaves them in a position where they can't determine whether some symbol, such as `Button` is defined or not. So there are two approaches to make the linters happy.

One approach is to make the import be something like

```python
import tkinter as tk
```

and then use things like `tk.Button` throughout the module.

The other approach (which I've taken) is to do something like

```python
from tkinter import (
    Button,
    CENTER,
    ...,  # 10 more lines like this
)
```

If this were my own code, I would do things the first way, but I wanted to make the minimal changes for this PR. But either way, I do feel that the linters are correct in complaining about the existing code: It is nice to keep name spaces clearer.

