### PR TITLE
More robust argument handling for Enigma

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,171 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# PyPI configuration file
+.pypirc

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "."
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/python_enigma/enigma.py
+++ b/python_enigma/enigma.py
@@ -22,6 +22,8 @@ Development was by Zac Adam-MacEwen. See the README.md for details.
 # General Purpose Imports Block
 import json
 import os
+from typing import Any
+from collections.abc import Sequence
 
 
 class SteckerSettingsInvalid(Exception):
@@ -306,13 +308,22 @@ class Enigma(object):
     - set: change various settings. See below.
     """
 
-    def __init__(self, catalog={}, stecker="", stator="military",
-                 rotors=[["I",0], ["II",0], ["III",0]],
-                 reflector="UKW", operator=True, word_length=5,
+    def __init__(self,
+                 catalog: dict[str, Any] | str = "default",
+                 stecker: str | Sequence[str] = "ZZZ",
+                 stator="military",
+                 rotors: Sequence[Sequence[str]] = (
+                        ("I", 'A'), ("II", 'A'), ("III", 'A')
+                     ),
+                 reflector="UKW",
+                 operator: bool | Operator = True,
+                 word_length=5,
                  ignore_static_wheels=False):
-        self.stecker = Stecker(setting=str(stecker))
+        stecker = ''.join(stecker)
+        self.stecker = Stecker(setting=stecker)
         self.stator = Stator(mode=stator)
-        self.rotor_names = rotors
+        # We want to _copy_ values for rotors, as original might be mutable.
+        self.rotor_names = tuple((w[0], w[1]) for w in rotors)
         self.reflector_name = reflector
         self.operator_param = operator
         self.ignore_static_wheels = ignore_static_wheels
@@ -325,7 +336,7 @@ class Enigma(object):
                 catalog = json.load(file)
         self.catalog = catalog
         wheels = []
-        rotors.reverse()
+        rotors = rotors[::-1]  # reverse the tuple
         for rotor in rotors:
             rotor_req = rotor[0]
             ringstellung = rotor[1]

--- a/python_enigma/enigma.py
+++ b/python_enigma/enigma.py
@@ -60,11 +60,11 @@ class Stecker(object):
         """Accepts a string of space-seperated letter pairs denoting stecker
          settings, deduplicates them and grants the object its properties.
         """
+        self.stecker_setting: dict[str, str] = {}
         if setting is not None:
             stecker_pairs = setting.upper().split(" ")
             used_characters = []
             valid_chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-            self.stecker_setting = {}
             for pair in stecker_pairs:
                 if (pair[0] in used_characters) or (pair[1] in used_characters):
                     raise SteckerSettingsInvalid
@@ -310,7 +310,7 @@ class Enigma(object):
 
     def __init__(self,
                  catalog: dict[str, Any] | str = "default",
-                 stecker: str | Sequence[str] = "ZZZ",
+                 stecker: str | None = None,
                  stator="military",
                  rotors: Sequence[Sequence[str]] = (
                         ("I", 'A'), ("II", 'A'), ("III", 'A')
@@ -319,7 +319,6 @@ class Enigma(object):
                  operator: bool | Operator = True,
                  word_length=5,
                  ignore_static_wheels=False):
-        stecker = ''.join(stecker)
         self.stecker = Stecker(setting=stecker)
         self.stator = Stator(mode=stator)
         # We want to _copy_ values for rotors, as original might be mutable.

--- a/tests/test_cryption.py
+++ b/tests/test_cryption.py
@@ -1,0 +1,65 @@
+import sys
+import pytest
+
+from python_enigma import enigma
+
+
+class TestEncrypt:
+    def test_hello(self) -> None:
+        plaintext = "hello world"
+        expected_ctext = "ILJDQ QMTQZ"
+        word_length = 5
+        expected_ptext = "HELLO WORLD"
+
+        rotors = [("I", "A"), ("II", "B"), ("III", "C")]
+        machine = enigma.Enigma(
+            catalog="default",
+            stecker="AQ BJ",
+            rotors=rotors,
+            reflector="Reflector B",
+            operator=True,
+            word_length=word_length,
+            stator="military",
+        )
+
+        machine.set_wheels("ABC")
+        ctext = machine.parse(plaintext)
+        assert ctext == expected_ctext
+
+        machine.set_wheels("ABC")
+        decrypted = machine.parse(ctext)
+        assert decrypted == expected_ptext
+
+
+class TestHistorical:
+    """Tests taken from https://gist.github.com/Jither/d8dbc4d38998c18686bb646b49b9a8a6"""
+
+    # @pytest.mark.skip("I can't get this working")
+    def test_p1030681(self) -> None:
+        wheels: list[str] = ["Beta", "V", "VI", "VIII"]
+        rotor_positions = "CDSZ"
+        ring_settings = "EPEL"
+        reflector = "Reflector C Thin"
+        plug_board = "AE BF CM DQ HU JN LX PR SZ VW"
+        rotors = list(zip(wheels, list(rotor_positions)))
+
+        ctext = "LANOTCTOUARBBFPMHPHGCZXTDYGAHGUFXGEWKBLKGJWLQXXTGPJJAVTOCKZFSLPPQIHZFXOEBWIIEKFZLCLOAQJULJOYHSSMBBGWHZANVOIIPYRBRTDJQDJJOQKCXWDNBBTYVXLYTAPGVEATXSONPNYNQFUDBBHHVWEPYEYDOHNLXKZDNWRHDUWUJUMWWVIIWZXIVIUQDRHYMNCYEFUAPNHOTKHKGDNPSAKNUAGHJZSMJBMHVTREQEDGXHLZWIFUSKDQVELNMIMITHBHDBWVHDFYHJOQIHORTDJDBWXEMEAYXGYQXOHFDMYUXXNOJAZRSGHPLWMLRECWWUTLRTTVLBHYOORGLGOWUXNXHMHYFAACQEKTHSJW"
+
+        ptext = "KRKRALLEXXFOLGENDESISTSOFORTBEKANNTZUGEBENXXICHHABEFOLGELNBEBEFEHLERHALTENXXJANSTERLEDESBISHERIGXNREICHSMARSCHALLSJGOERINGJSETZTDERFUEHRERSIEYHVRRGRZSSADMIRALYALSSEINENNACHFOLGEREINXSCHRIFTLSCHEVOLLMACHTUNTERWEGSXABSOFORTSOLLENSIESAEMTLICHEMASSNAHMENVERFUEGENYDIESICHAUSDERGEGENWAERTIGENLAGEERGEBENXGEZXREICHSLEITEIKKTULPEKKJBORMANNJXXOBXDXMMMDURNHFKSTXKOMXADMXUUUBOOIEXKP"
+
+        machine = enigma.Enigma(
+            catalog="default",
+            stecker=plug_board,
+            stator="military",
+            rotors=rotors,
+            reflector=reflector,
+            operator=False,
+        )
+        machine.set_wheels(ring_settings)
+
+        decrypted = machine.parse(ctext)
+        assert decrypted == ptext
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(args=[__file__]))

--- a/tests/test_cryption.py
+++ b/tests/test_cryption.py
@@ -1,4 +1,5 @@
 import sys
+from collections import Counter
 import pytest
 
 from python_enigma import enigma
@@ -59,6 +60,38 @@ class TestHistorical:
 
         decrypted = machine.parse(ctext)
         assert decrypted == ptext
+
+    def test_greek_advance(self) -> None:
+        wheels: list[str] = ["Beta", "V", "VI", "VIII"]
+        rotor_positions = "CDSZ"
+        ring_settings = "EPEL"
+        reflector = "Reflector C Thin"
+        plug_board = "AE BF CM DQ HU JN LX PR SZ VW"
+        rotors = list(zip(wheels, list(rotor_positions)))
+
+        ptext = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+
+        machine = enigma.Enigma(
+            catalog="default",
+            stecker=plug_board,
+            stator="military",
+            rotors=rotors,
+            reflector=reflector,
+            operator=False,
+        )
+        machine.set_wheels(ring_settings)
+
+        (p_most_common, p_most_commen_count) = Counter(ptext).most_common(1)[0]
+
+        # just checking the counter logic
+        assert p_most_common == "A"
+        assert p_most_commen_count == len(ptext)
+
+        ctext = machine.parse(ptext)
+        (_, c_most_commen_count) = Counter(ctext).most_common(1)[0]
+
+        # This test will fail if rotors aren't advancing
+        assert c_most_commen_count != len(ctext)
 
 
 if __name__ == "__main__":

--- a/tests/test_cryption.py
+++ b/tests/test_cryption.py
@@ -33,30 +33,6 @@ class TestEncrypt:
         decrypted = machine.parse(ctext)
         assert decrypted == expected_ptext
 
-    def test_hello_noop(self) -> None:
-        plaintext = "helloworld".upper()
-        expected_ctext = "ILJDQQMTQZ"
-        word_length = 5
-        expected_ptext = "HELLOWORLD"
-
-        rotors = [("I", "A"), ("II", "B"), ("III", "C")]
-        machine = enigma.Enigma(
-            catalog="default",
-            stecker="AQ BJ",
-            rotors=rotors,
-            reflector="Reflector B",
-            operator=False,
-            stator="military",
-        )
-
-        machine.set_wheels("ABC")
-        ctext = machine.parse(plaintext)
-        assert ctext == expected_ctext
-
-        machine.set_wheels("ABC")
-        decrypted = machine.parse(ctext)
-        assert decrypted == expected_ptext
-
 
 class TestHistorical:
     """Tests taken from https://gist.github.com/Jither/d8dbc4d38998c18686bb646b49b9a8a6"""
@@ -240,6 +216,27 @@ class TestDefault:
 
     def test_ignore_static_wheels(self) -> None:
         self.default_test("ignore_static_wheels")
+
+
+class TestMutation:
+    def test_rotor_mutation(self) -> None:
+        plaintext = "hello world"
+        word_length = 5
+        rotors = [("I", "A"), ("II", "B"), ("III", "C")]
+        rotors_copy = rotors.copy()
+        machine = enigma.Enigma(
+            catalog="default",
+            stecker="AQ BJ",
+            rotors=rotors,
+            reflector="Reflector B",
+            operator=True,
+            word_length=word_length,
+            stator="military",
+        )
+
+        machine.set_wheels("ABC")
+        _ = machine.parse(plaintext)
+        assert rotors == rotors_copy
 
 
 if __name__ == "__main__":

--- a/tests/test_cryption.py
+++ b/tests/test_cryption.py
@@ -238,6 +238,30 @@ class TestMutation:
         _ = machine.parse(plaintext)
         assert wheels == wheels_copy
 
+    def test_machine_mutation(self) -> None:
+        """Fails if external change in rotors changes machine behavior."""
+        plaintext = "hello world"
+
+        wheels = [("I", "A"), ("II", "B"), ("III", "C")]
+
+        machine = enigma.Enigma(
+            catalog="default",
+            stecker="AQ BJ",
+            rotors=wheels,
+            reflector="Reflector B",
+            stator="military",
+        )
+
+        machine.set_wheels("ABC")
+        ctext1 = machine.parse(plaintext)
+
+        # Now we change wheels here
+        wheels = [("IV", "A"), ("V", "B"), ("VI", "C")]
+        machine.set_wheels("ABC")
+        ctext2 = machine.parse(plaintext)
+
+        assert ctext1 == ctext2
+
 
 if __name__ == "__main__":
     sys.exit(pytest.main(args=[__file__]))

--- a/tests/test_cryption.py
+++ b/tests/test_cryption.py
@@ -31,6 +31,30 @@ class TestEncrypt:
         decrypted = machine.parse(ctext)
         assert decrypted == expected_ptext
 
+    def test_hello_noop(self) -> None:
+        plaintext = "helloworld".upper()
+        expected_ctext = "ILJDQQMTQZ"
+        word_length = 5
+        expected_ptext = "HELLOWORLD"
+
+        rotors = [("I", "A"), ("II", "B"), ("III", "C")]
+        machine = enigma.Enigma(
+            catalog="default",
+            stecker="AQ BJ",
+            rotors=rotors,
+            reflector="Reflector B",
+            operator=False,
+            stator="military",
+        )
+
+        machine.set_wheels("ABC")
+        ctext = machine.parse(plaintext)
+        assert ctext == expected_ctext
+
+        machine.set_wheels("ABC")
+        decrypted = machine.parse(ctext)
+        assert decrypted == expected_ptext
+
 
 class TestHistorical:
     """Tests taken from https://gist.github.com/Jither/d8dbc4d38998c18686bb646b49b9a8a6"""
@@ -48,13 +72,15 @@ class TestHistorical:
 
         ptext = "KRKRALLEXXFOLGENDESISTSOFORTBEKANNTZUGEBENXXICHHABEFOLGELNBEBEFEHLERHALTENXXJANSTERLEDESBISHERIGXNREICHSMARSCHALLSJGOERINGJSETZTDERFUEHRERSIEYHVRRGRZSSADMIRALYALSSEINENNACHFOLGEREINXSCHRIFTLSCHEVOLLMACHTUNTERWEGSXABSOFORTSOLLENSIESAEMTLICHEMASSNAHMENVERFUEGENYDIESICHAUSDERGEGENWAERTIGENLAGEERGEBENXGEZXREICHSLEITEIKKTULPEKKJBORMANNJXXOBXDXMMMDURNHFKSTXKOMXADMXUUUBOOIEXKP"
 
+        ptext = enigma.Operator(5).format(ptext)
+
         machine = enigma.Enigma(
             catalog="default",
             stecker=plug_board,
             stator="military",
             rotors=rotors,
             reflector=reflector,
-            operator=False,
+            operator=True,
         )
         machine.set_wheels(ring_settings)
 
@@ -92,6 +118,77 @@ class TestHistorical:
 
         # This test will fail if rotors aren't advancing
         assert c_most_commen_count != len(ctext)
+
+        # Now we reset wheels and do the same thing again
+        machine.set_wheels(ring_settings)
+        ctext2 = machine.parse(ptext)
+
+        assert ctext2 == ctext
+
+
+class TestOperatorIssue:
+    def testWeirdBug(self) -> None:
+        """Testing for bug I cannot reproduce"""
+
+        # copying as closely as I can from case where issue shows up
+        stator = "military"
+        reflector = "Reflector C Thin"
+
+        greek_wheel = "Beta"
+        wheels = [greek_wheel, "V", "VII", "VIII"]
+        ring_settings = "EPEL"
+        plug_board = "AE BF CM DQ HU JN LX PR SZ VW"
+        rotor_position = "CDSZ"
+
+        rotors = list(zip(wheels, list(rotor_position)))
+
+        machine = enigma.Enigma(
+            catalog="default",
+            rotors=rotors,
+            stecker=plug_board,
+            reflector=reflector,
+            operator=False,
+            word_length=5,
+            stator=stator,
+        )
+        machine.set_wheels(ring_settings)
+
+        ptext = 'A' * 20
+
+        operator = enigma.Operator(word_length=5)
+
+        ptext = operator.format(ptext)
+
+        ctext = machine.parse(ptext)
+
+
+        # This test will fail if rotors aren't advancing
+        assert ctext[0] != ctext[1]
+
+        # Now we reset wheels and do the same thing again
+        machine.set_wheels(ring_settings)
+        ctext2 = machine.parse(ptext)
+
+        assert ctext2 == ctext
+
+
+class TestDefault:
+    """Attempt to test that the mutable defaults don't cause problems."""
+
+    def test_default_rotor(self):
+        machine1 = enigma.Enigma(catalog="default", stecker="DEF")
+        machine1.set_wheels("XYZ")
+
+        machine2 = enigma.Enigma(catalog="default", stecker="DEF")
+        machine2.set_wheels("XYZ")
+        machine2.set_stecker("DEF")
+
+        ptext = "AAAAAAAAAAAAAAAA"
+
+        ctext1 = machine1.parse(ptext)
+        ctext2 = machine2.parse(ptext)
+
+        assert ctext1 == ctext2
 
 
 if __name__ == "__main__":

--- a/tests/test_cryption.py
+++ b/tests/test_cryption.py
@@ -220,23 +220,23 @@ class TestDefault:
 
 class TestMutation:
     def test_rotor_mutation(self) -> None:
+        """Fails if reference passed as rotors argument gets mutated"""
         plaintext = "hello world"
-        word_length = 5
-        rotors = [("I", "A"), ("II", "B"), ("III", "C")]
-        rotors_copy = rotors.copy()
+
+        wheels = [("I", "A"), ("II", "B"), ("III", "C")]
+        wheels_copy = wheels.copy()
+
         machine = enigma.Enigma(
             catalog="default",
             stecker="AQ BJ",
-            rotors=rotors,
+            rotors=wheels,
             reflector="Reflector B",
-            operator=True,
-            word_length=word_length,
             stator="military",
         )
 
         machine.set_wheels("ABC")
         _ = machine.parse(plaintext)
-        assert rotors == rotors_copy
+        assert wheels == wheels_copy
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This 
resolves #17
and
resolves #18

Most of the changes are to the parameter defaults in `Enigma.__init__(), but some other changes are to

1. Only mutate copies of what is passed in.
2. Make things more robust in terms of types to allow caller to pass immutable objects
3. Fix for Stator class when settings is None

This also includes 

- Pytest tests, but don't require that the tests be run
- A `.gitignore` file which doesn't change the code at all, but makes it easier to manage git.
- A vscode settings file which helps running tests in VSCode

None of that touches the actual operation of the code.

Note that although some (abstract) type annotations have been added, none of these changes change the minimum Python version (3.6) that this runs under.